### PR TITLE
Add macOS compiler compatibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() {
     cxx_build::bridge("src/inner.rs")
         .define("RYML_SINGLE_HDR_DEFINE_NOW", None)
         .define("C4CORE_SINGLE_HDR_DEFINE_NOW", None)
+        .flag_if_supported("-std=c++17")
         .compile("ryml");
     println!("cargo:rerun-if-changed=src/inner.rs");
     println!("cargo:rerun-if-changed=src/shim.cc");

--- a/include/ryml.h
+++ b/include/ryml.h
@@ -1752,7 +1752,7 @@ __inline__ static void trap_instruction(void)
 	 * Same problem and workaround as Thumb mode */
 }
 #elif defined(__aarch64__) && defined(__APPLE__)
-	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BULTIN_DEBUGTRAP
+	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_BULTIN_TRAP
 #elif defined(__aarch64__)
 	#define DEBUG_BREAK_IMPL DEBUG_BREAK_USE_TRAP_INSTRUCTION
 __attribute__((always_inline))


### PR DESCRIPTION
Tried compiling with macOS. GNU GCC should be fine on Intel, but with default clang, I saw a long error log that included this:
```
crate/ryml/include/ryml.h:845:13: error: C++ lesser than C++11 not supported
  cargo:warning=#           error C++ lesser than C++11 not supported
```

It seems the `-std=c++17` flag is not being set properly for clang. I added it and tested the compilation with clang on Intel macOS.

Additionally, the following error shows up when compiling with gcc on Apple Silicon:
```
include/ryml.h:1810:9: error: '__builtin_debugtrap' was not declared in this scope; did you mean '__builtin_trap'?
  cargo:warning= 1810 |         __builtin_debugtrap();
  cargo:warning=      |         ^~~~~~~~~~~~~~~~~~~
  cargo:warning=      |         __builtin_trap
```
I changed the macro to what I think is appropriate given the error message, and after both changes, compilation succeeds with both gcc and clang on Apple Silicon