### PR TITLE
Fix casts for char pointers

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -668,7 +668,7 @@ seq: [0 ,  1, 2, 3]"#;
     #[test]
     fn mut_tree() -> Result<(), cxx::Exception> {
         let mut src = SRC.to_string();
-        let mut tree = unsafe { ffi::parse_in_place(src.as_mut_ptr() as *mut i8, src.len())? };
+        let mut tree = unsafe { ffi::parse_in_place(src.as_mut_ptr() as *mut core::ffi::c_char, src.len())? };
         let bar_val = tree.find_child(0, &("bar".into()))?;
         tree.pin_mut()._set_val(bar_val, "r353".into(), 0)?;
         println!("{}", &src);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl<'a> Tree<'a> {
     #[inline(always)]
     pub fn parse_in_place(mut text: impl AsMut<str> + 'a) -> Result<Tree<'a>> {
         let tree = unsafe {
-            inner::ffi::parse_in_place(text.as_mut().as_mut_ptr() as *mut i8, text.as_mut().len())
+            inner::ffi::parse_in_place(text.as_mut().as_mut_ptr() as *mut core::ffi::c_char, text.as_mut().len())
         }?;
         Ok(Self {
             inner: tree,


### PR DESCRIPTION
This should fix building on linux ARM devices, which use `*mut u8` instead of `*mut i8` for char pointers. 

See https://hydra.nixos.org/build/268542995/nixlog/1.